### PR TITLE
Add tests for Metrics subsystem configuration

### DIFF
--- a/.github/workflows/manual-test-matrix-workflow.yaml
+++ b/.github/workflows/manual-test-matrix-workflow.yaml
@@ -26,6 +26,7 @@ jobs:
             "jpa",
             "jsf",
             "mail",
+            "metrics",
             "runtime",
             "system-property",
             "weld",

--- a/.github/workflows/scheduled-run-all-tests-workflow.yaml
+++ b/.github/workflows/scheduled-run-all-tests-workflow.yaml
@@ -28,6 +28,7 @@ jobs:
             "jpa",
             "jsf",
             "mail",
+            "metrics",
             "runtime",
             "system-property",
             "weld",

--- a/packages/testsuite/cypress/e2e/metrics/test-configuration-subsystem-metrics.cy.ts
+++ b/packages/testsuite/cypress/e2e/metrics/test-configuration-subsystem-metrics.cy.ts
@@ -1,0 +1,65 @@
+describe("TESTS: Configuration => Subsystem => Metrics", () => {
+  const address = ["subsystem", "metrics"];
+  const configurationFormId = "model-browser-model-browser-root-form";
+
+  const exposedSubsystems = "exposed-subsystems";
+  const exposedSubsystemsForm =
+    '[data-form-item-group="model-browser-model-browser-root-form-exposed-subsystems-editing"]';
+  const exposedSubsystemsDefaultValue = "*";
+  const exposedSubsystemsCustomValue = "subsystems-to-update";
+  const prefix = "prefix";
+  const customPrefixValue = "wildfly.metrics.prefix:custom_prefix";
+  const securityEnabled = "security-enabled";
+
+  let managementEndpoint: string;
+
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Edit exposed subsystems", () => {
+    cy.navigateToGenericSubsystemPage(managementEndpoint, address);
+    cy.editForm(configurationFormId);
+    cy.clearListAttributeItems(exposedSubsystemsForm);
+    cy.formInput(configurationFormId, exposedSubsystems)
+      .clear()
+      .type(exposedSubsystemsCustomValue + "{enter}")
+      .trigger("change");
+    cy.saveForm(configurationFormId);
+    cy.verifySuccess();
+    cy.verifyListAttributeContains(managementEndpoint, address, exposedSubsystems, exposedSubsystemsCustomValue);
+    cy.verifyListAttributeDoesNotContain(managementEndpoint, address, exposedSubsystems, exposedSubsystemsDefaultValue);
+  });
+
+  it("Edit prefix", () => {
+    cy.navigateToGenericSubsystemPage(managementEndpoint, address);
+    cy.editForm(configurationFormId);
+    cy.text(configurationFormId, prefix, customPrefixValue);
+    cy.saveForm(configurationFormId);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, prefix, customPrefixValue);
+  });
+
+  it("Toggle security-enabled", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, securityEnabled).then((defaultValue) => {
+      cy.navigateToGenericSubsystemPage(managementEndpoint, address);
+      cy.editForm(configurationFormId);
+      cy.flip(configurationFormId, securityEnabled, defaultValue);
+      cy.saveForm(configurationFormId);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, securityEnabled, !defaultValue);
+    });
+  });
+
+  it("Reset configuration", () => {
+    cy.navigateToGenericSubsystemPage(managementEndpoint, address);
+    cy.get('#model-browser-model-browser-root-form-links > [data-toggle="tooltip"]');
+    cy.resetForm(configurationFormId, managementEndpoint, address);
+  });
+});

--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -118,6 +118,15 @@ Cypress.Commands.add("clearAttribute", (formId, attributeName) => {
   cy.formInput(formId, attributeName).trigger("change");
 });
 
+Cypress.Commands.add("clearListAttributeItems", (attributeName) => {
+  cy.get(attributeName)
+    .get("div.tag-manager-container")
+    .children("span")
+    .each((span) => {
+      cy.wrap(span).find("a[href]").click({ multiple: true });
+    });
+});
+
 export {};
 /* eslint @typescript-eslint/no-namespace: off */
 declare global {
@@ -193,6 +202,13 @@ declare global {
        * @param value - the value which needs to be write to form input.
        */
       text(formId: string, attributeName: string, value: string | number): Chainable<void>;
+      /**
+       * Clear all selected list attribute items from the form input.
+       * @category Data removing
+       *
+       * @param attributeName - name of form input.
+       */
+      clearListAttributeItems(attributeName: string): Chainable<void>;
       /**
        * Remove text value from form input.
        * @category Data inserting


### PR DESCRIPTION
**Resources to cover**

Expected resources to cover from `/subsystem=metrics:read-resource(recursive=true):`

- [x]  /subsystem=metrics/exposed-subsystems
- [x]  /subsystem=metrics/prefix
- [x]  /subsystem=metrics/security-enabled

Fixes https://github.com/hal/berg/issues/13