### PR TITLE
Add test for EAP7-1984

### DIFF
--- a/.github/workflows/manual-test-matrix-workflow.yaml
+++ b/.github/workflows/manual-test-matrix-workflow.yaml
@@ -31,7 +31,10 @@ jobs:
             "weld",
             "homepage",
             "smoke",
+            "update-manager",
           ]
+        exclude:
+          - specs: "update-manager"
     name: "Run tests"
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/scheduled-run-all-tests-workflow.yaml
+++ b/.github/workflows/scheduled-run-all-tests-workflow.yaml
@@ -33,7 +33,10 @@ jobs:
             "weld",
             "homepage",
             "smoke",
+            "update-manager",
           ]
+        exclude:
+          - specs: "update-manager"
     name: "Run tests"
     runs-on: "ubuntu-latest"
     steps:

--- a/packages/testsuite/cypress/e2e/homepage/test-homepage.cy.ts
+++ b/packages/testsuite/cypress/e2e/homepage/test-homepage.cy.ts
@@ -58,6 +58,20 @@ describe("TESTS: Homepage", () => {
     });
   });
 
+  it("Should load Update Manager page if product version is EAP", function() {
+    cy.get("#about-modal").then(($productInfo) => {
+      if ($productInfo.text().includes("EAP")) {
+        cy.get("#tlc-installer").click();
+        cy.get("#hal-finder-preview").should("be.visible");
+        cy.url().should((url) => {
+          expect(url).to.contain("#update-manager");
+        });
+      } else {
+        this.skip();
+      }
+    });
+  });
+
   it("Should load Access Control page", () => {
     cy.get("#tlc-access-control").click();
     cy.get("#hal-finder-preview").should("be.visible");

--- a/packages/testsuite/cypress/e2e/update-manager/test-configuration-update-channel.cy.ts
+++ b/packages/testsuite/cypress/e2e/update-manager/test-configuration-update-channel.cy.ts
@@ -1,0 +1,108 @@
+describe("TESTS: Update Manager => Channels", () => {
+    let managementEndpoint: string;
+  
+    const address = ["update-manager", "channels"];
+    const channelForm = "channel-form"
+
+    const channels = {
+        gav: {
+            name: "gav-channel",
+            repositories: "nexus-id-1,https://repository.jboss.org/nexus/content/groups/public/",
+            manifest: "org.jboss.eap.channels:wfnew",
+        },
+        url: {
+            name: "online-channel",
+            repositories: "nexus-id-1,https://repository.jboss.org/nexus/content/groups/public/",
+            manifest: "https://repository.jboss.org/nexus/content/groups/public/",
+        },
+        updateGav: {
+            repositories: "maven-id-1,https://repo1.maven.org/maven2/",
+            manifest: "org.jboss.eap.channels:wfupdated",
+        },
+        updateUrl: {
+            repositories: "maven-id-1,https://repo1.maven.org/maven2/",
+            manifest: "https://repo1.maven.org/maven2/",
+        },
+    };
+
+  
+    before(() => {
+      cy.startWildflyContainer().then((result) => {
+        managementEndpoint = result as string;
+      });
+    });
+  
+    after(() => {
+      cy.task("stop:containers");
+    });
+    
+    it("Add new channel with gav", () => {
+      cy.navigateToUpdateManagerPage(managementEndpoint, address);
+      cy.get("#update-manager-channel-add").click();
+      cy.text(channelForm, "name", channels.gav.name);
+      cy.formInput(channelForm, "repositories")
+      .clear()
+      .type(channels.gav.repositories + "{enter}")
+      .trigger("change");
+      cy.text(channelForm, "manifestgav", channels.gav.manifest);
+      cy.confirmAddResourceWizard();
+      cy.get("#update-manager-channel > ul").contains(channels.gav.name)
+    });
+
+    it("Add new channel with url", () => {
+      cy.navigateToUpdateManagerPage(managementEndpoint, address);
+      cy.get("#update-manager-channel-add").click();
+      cy.text(channelForm, "name", channels.url.name);
+      cy.formInput(channelForm, "repositories")
+      .clear()
+      .type(channels.url.repositories + "{enter}")
+      .trigger("change");
+      cy.text(channelForm, "manifesturl", channels.url.manifest);
+      cy.confirmAddResourceWizard();
+      cy.get("#update-manager-channel > ul").contains(channels.url.name)
+    });
+    
+    it("Check view button", () => {
+      cy.navigateToUpdateManagerPage(managementEndpoint, address);
+      cy.get("#" + channels.gav.name).click();
+      cy.get("#" + channels.gav.name + " > div > a.clickable.btn.btn-finder:contains(\"View\")")
+      .should("be.visible").click();
+      cy.get("#hal-root-container").get("h1").contains("Channel")
+    });
+
+    it("Update gav channel parameters", () => {
+        cy.navigateToSpecificChannel(managementEndpoint, channels.gav.name)
+        cy.editForm(channelForm);
+        cy.formInput(channelForm, "repositories")
+        .clear()
+        .type(channels.updateGav.repositories + "{enter}")
+        .trigger("change");
+        cy.text(channelForm, "manifestgav", channels.updateGav.manifest);
+        cy.saveForm(channelForm);
+        cy.verifySuccess();
+    });
+
+    it("Update url channel parameters", () => {
+        cy.navigateToSpecificChannel(managementEndpoint, channels.url.name)
+        cy.editForm(channelForm);
+        cy.formInput(channelForm, "repositories")
+        .clear()
+        .type(channels.updateUrl.repositories + "{enter}")
+        .trigger("change");
+        cy.text(channelForm, "manifesturl", channels.updateUrl.manifest);
+        cy.saveForm(channelForm);
+        cy.verifySuccess();
+    });
+
+    it("Remove channel", () => {
+        cy.navigateToUpdateManagerPage(managementEndpoint, address);
+        cy.get("#" + channels.gav.name).click();
+        cy.get("#" + channels.gav.name + " > div > button.btn.btn-finder.dropdown-toggle")
+        .should("be.visible").click();
+        cy.get("#" + channels.gav.name + " > div > ul > li > a.clickable")
+        .should("be.visible").click();
+        cy.get('div.modal-footer > button.btn.btn-hal.btn-primary:contains("Yes")').click();
+        cy.verifySuccess();
+        cy.get("#update-manager-channel > ul > #" + channels.gav.name).should("not.exist");
+      });
+  });

--- a/packages/testsuite/cypress/e2e/update-manager/test-update-clean.cy.ts
+++ b/packages/testsuite/cypress/e2e/update-manager/test-update-clean.cy.ts
@@ -1,0 +1,22 @@
+describe("TESTS: Update Manager => Updates => Clean", () => {
+    let managementEndpoint: string;
+    let timeout_time = 30000 
+  
+    const address = ["update-manager", "updates"];
+  
+    before(() => {
+      cy.startWildflyContainer().then((result) => {
+        managementEndpoint = result as string;
+      });
+    });
+  
+    after(() => {
+      cy.task("stop:containers");
+    });
+    
+    it("Update server by custom patch", () => {
+      cy.navigateToUpdateManagerPage(managementEndpoint, address);
+      cy.get("#update-manager-clean").click();
+      cy.verifySuccess();
+    });
+});

--- a/packages/testsuite/cypress/e2e/update-manager/test-update-custom-patch.cy.ts
+++ b/packages/testsuite/cypress/e2e/update-manager/test-update-custom-patch.cy.ts
@@ -1,0 +1,43 @@
+describe("TESTS: Update Manager => Updates => Custom patches", () => {
+    let managementEndpoint: string;
+    let timeout_time = 30000 
+  
+    const address = ["update-manager", "updates"];
+    const zip_file = Cypress.env("PATCH_ZIP")
+    const artifactToBeUpdated = "com.amazonaws:aws-java-sdk-kms"
+  
+    before(() => {
+      cy.startWildflyContainer().then((result) => {
+        managementEndpoint = result as string;
+      });
+    });
+  
+    after(() => {
+      cy.task("stop:containers");
+    });
+    
+    it("Update server by custom patch", () => {
+      cy.navigateToUpdateManagerPage(managementEndpoint, address);
+      cy.get("#update-manager-update-add-actions").click();
+      cy.get("#update-manager-update-patch").click();
+      cy.get("input#update-manager-update-patch-form-custom-patch-file-editing").selectFile(zip_file,
+        {
+          action: "drag-drop",
+          force: true,
+        }
+      );
+      cy.text("update-manager-update-patch-form", "manifest", "org.jboss.qe.eap:one-off-1");
+      cy.confirmNextInWizard();
+      cy.get("#update-manager-list-updates", { timeout: timeout_time })
+      .should("be.visible").contains(artifactToBeUpdated);
+      cy.confirmNextInWizard();
+      cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+      .contains("Server candidate prepared");
+      cy.confirmNextInWizard();
+      cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+      .contains("Updates applied")
+      cy.confirmFinishInWizard();
+      // After the update there should be visible 3 items in history
+      cy.get("#update-manager-update > ul > li").should('have.length', 3)
+    });
+});

--- a/packages/testsuite/cypress/e2e/update-manager/test-update-offline-archive.cy.ts
+++ b/packages/testsuite/cypress/e2e/update-manager/test-update-offline-archive.cy.ts
@@ -1,0 +1,42 @@
+describe("TESTS: Update Manager => Updates => Offline using archive", () => {
+  let managementEndpoint: string;
+  let timeout_time = 30000 
+
+  const address = ["update-manager", "updates"];
+  const zip_file = Cypress.env("UPDATE_ZIP")
+  const artifactToBeUpdated = "com.amazonaws:aws-java-sdk-kms"
+
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+  
+  it("Ofline update from zip", () => {
+    cy.navigateToUpdateManagerPage(managementEndpoint, address);
+    cy.get("#update-manager-update-add-actions").click();
+    cy.get("#update-manager-update-offline").click();
+    cy.get("input#upload-file-input").selectFile(zip_file,
+      {
+        action: "drag-drop",
+        force: true,
+      }
+    );
+    cy.confirmNextInWizard();
+    cy.get("#update-manager-list-updates", { timeout: timeout_time })
+    .should("be.visible").contains(artifactToBeUpdated);
+    cy.confirmNextInWizard();
+    cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+    .contains("Server candidate prepared");
+    cy.confirmNextInWizard();
+    cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+    .contains("Updates applied")
+    cy.confirmFinishInWizard();
+    // After the update there should be visible 3 items in history
+    cy.get("#update-manager-update > ul > li").should('have.length', 3)
+  });
+});

--- a/packages/testsuite/cypress/e2e/update-manager/test-update-online-and-revert-back.cy.ts
+++ b/packages/testsuite/cypress/e2e/update-manager/test-update-online-and-revert-back.cy.ts
@@ -1,0 +1,51 @@
+describe("TESTS: Update Manager => Updates => Online updates => Revert", () => {
+    let managementEndpoint: string;
+    let timeout_time = 30000 
+  
+    const address = ["update-manager", "updates"];
+    const artifactToBeUpdated = "com.amazonaws:aws-java-sdk-kms"
+  
+    before(() => {
+      cy.startWildflyContainer().then((result) => {
+        managementEndpoint = result as string;
+      });
+    });
+  
+    after(() => {
+      cy.task("stop:containers");
+    });
+    
+    it("Ofline update from zip", () => {
+        cy.navigateToUpdateManagerPage(managementEndpoint, address);
+        cy.get("#update-manager-update-add-actions").click();
+        cy.get("#update-manager-update-online").click();
+        cy.get("#update-manager-list-updates", { timeout: timeout_time })
+        .should("be.visible").contains(artifactToBeUpdated);
+        cy.confirmNextInWizard();
+        cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+        .contains("Server candidate prepared");
+        cy.confirmNextInWizard();
+        cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+        .contains("Updates applied")
+        cy.confirmFinishInWizard();
+        // After the update there should be visible 3 items in history
+        cy.get("#update-manager-update > ul > li").should('have.length', 3)
+    });
+
+    it("Ofline update from zip", () => {
+      cy.navigateToUpdateManagerPage(managementEndpoint, address);
+      cy.get("#update-manager-update > ul > li").first().click();
+      cy.get("#update-manager-update > ul > li > a.clickable.btn.btn-finder").first().click();
+      cy.get("#update-manager-list-updates", { timeout: timeout_time })
+      .should("be.visible").contains(artifactToBeUpdated);
+      cy.confirmNextInWizard();
+      cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+      .contains("Server candidate prepared");
+      cy.confirmNextInWizard();
+      cy.get("div.blank-slate-pf.wizard-pf-complete", { timeout: timeout_time })
+      .contains("Updates applied")
+      cy.confirmFinishInWizard();
+      // After the update there should be visible 3 items in history
+      cy.get("#update-manager-update > ul > li").should('have.length', 4)
+    });
+  });

--- a/packages/testsuite/cypress/support/navigation.ts
+++ b/packages/testsuite/cypress/support/navigation.ts
@@ -11,6 +11,11 @@ Cypress.Commands.add("navigateToGenericSubsystemPage", (managementEndpoint, addr
   cy.get("#hal-root-container").should("be.visible");
 });
 
+Cypress.Commands.add("navigateToSpecificChannel", (managementEndpoint, channel) => {
+  cy.visit(`?connect=${managementEndpoint}#channel;name=${channel}`);
+  cy.get("#hal-root-container").should("be.visible");
+});
+
 Cypress.Commands.add("selectInTable", (tableId, resourceName) => {
   const tableWrapper = `#${tableId}_wrapper`;
   cy.get(`${tableWrapper} td:contains("${resourceName}")`).click();
@@ -18,6 +23,20 @@ Cypress.Commands.add("selectInTable", (tableId, resourceName) => {
 
 Cypress.Commands.add("confirmAddResourceWizard", () => {
   cy.get('div.modal-footer > button.btn.btn-hal.btn-primary:contains("Add")').click({ force: true });
+});
+
+Cypress.Commands.add("confirmNextInWizard", () => {
+  cy.get('div.modal-footer > button.btn.btn-primary:contains("Next")').click({ force: true });
+});
+
+Cypress.Commands.add("confirmFinishInWizard", () => {
+  cy.get('div.modal-footer > button.btn.btn-primary:contains("Finish")').click({ force: true });
+});
+
+Cypress.Commands.add("navigateToUpdateManagerPage", (managementEndpoint, address) => {
+  const subsystemSeparator = "~";
+  cy.visit(`?connect=${managementEndpoint}#update-manager;path=${address.join(subsystemSeparator)}`);
+  cy.get("#hal-root-container").should("be.visible");
 });
 
 export {};
@@ -42,6 +61,14 @@ declare global {
        */
       navigateToGenericSubsystemPage(managementEndpoint: string, address: string[]): Chainable<void>;
       /**
+       * Load a channel page
+       * @category Navigation
+       *
+       * @param managementEndpoint - Host name of currently used container.
+       * @param channel - The name of channel.
+       */
+      navigateToSpecificChannel(managementEndpoint: string, channel: string): Chainable<void>;
+      /**
        * Select resource in table.
        * @category Navigation
        *
@@ -54,6 +81,24 @@ declare global {
        * @category Navigation
        */
       confirmAddResourceWizard(): void;
+      /**
+       * Confirm the next resource dialog
+       * @category Navigation
+       */
+      confirmNextInWizard(): void;
+      /**
+       * Confirm the finish resource dialog
+       * @category Navigation
+       */
+      confirmFinishInWizard(): void;
+      /**
+       * Load a Update Manager page
+       * @category Navigation
+       *
+       * @param managementEndpoint - Host name of currently used container.
+       * @param address - key words from URL parameter "address". e.g. "update-manager" and "updates"
+       */
+      navigateToUpdateManagerPage(managementEndpoint: string, address: string[]): Chainable<void>;
     }
   }
 }


### PR DESCRIPTION
Hi, this PR adding test coverage for [EAP7-1984](https://issues.redhat.com/browse/EAP7-1984). It's cover added provisioning which was added in [HAL-1827](https://issues.redhat.com/browse/HAL-1827).

The added test coverage should be working only with EAP. When working with WildFly none of these pages should be visible.

#### Homepage test

[HAL-1827](https://issues.redhat.com/browse/HAL-1827) removing the update server by patch command and adding updating by installer command. This PR updating the homepage patch test to homepage update-manager test. This test will run only with EAP as with WildFly this should not be visible.

#### Update-manager

Adding test coverage for installer functions. That is online and offline update from channel, update by custom patch and add/remove/update channel. These test should be run only with EAP server provisioned by installer. With WildFly these function should not be visible and not working. 