### PR TITLE
Fixing relative-to test for Configuration => Subsystem => Deployment Scanner

### DIFF
--- a/packages/testsuite/cypress/e2e/deployment-scanner/test-configuration-subsystem-deployment-scanner.cy.ts
+++ b/packages/testsuite/cypress/e2e/deployment-scanner/test-configuration-subsystem-deployment-scanner.cy.ts
@@ -150,9 +150,9 @@ describe("TESTS: Configuration => Subsystem => Deployment Scanner", () => {
     cy.navigateTo(managementEndpoint, "deployment-scanner");
     cy.selectInTable(deploymentScannerTableId, deploymentScanners.update.name);
     cy.editForm(configurationFormId);
-    cy.text(configurationFormId, relativeTo, "another-dir");
+    cy.text(configurationFormId, relativeTo, "jboss.server.base.dir");
     cy.saveForm(configurationFormId);
-    cy.verifyAttribute(managementEndpoint, address.concat(deploymentScanners.update.name), relativeTo, "another-dir");
+    cy.verifyAttribute(managementEndpoint, address.concat(deploymentScanners.update.name), relativeTo, "jboss.server.base.dir");
   });
 
   it("Toggle runtime-failure-causes-rollback", () => {


### PR DESCRIPTION
Replace with drop down menu value, e.g. jboss.server.base.dir

Local run
```
  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        12                                                                               │
  │ Passing:      12                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     42 seconds                                                                       │
  │ Spec Ran:     test-configuration-subsystem-deployment-scanner.cy.ts                            │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  test-configuration-subsystem-deploy      00:42       12       12        -        -        - │
  │    ment-scanner.cy.ts                                                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:42       12       12        -        -        -  

```