### PR TITLE
Fix homepage

### DIFF
--- a/packages/testsuite/cypress/e2e/homepage/test-homepage.cy.ts
+++ b/packages/testsuite/cypress/e2e/homepage/test-homepage.cy.ts
@@ -58,14 +58,6 @@ describe("TESTS: Homepage", () => {
     });
   });
 
-  it("Should load Patching page", () => {
-    cy.get("#tlc-patching").click();
-    cy.get("#hal-finder-preview").should("be.visible");
-    cy.url().should((url) => {
-      expect(url).to.contain("#patching");
-    });
-  });
-
   it("Should load Access Control page", () => {
     cy.get("#tlc-access-control").click();
     cy.get("#hal-finder-preview").should("be.visible");


### PR DESCRIPTION
Patching is removed in EAP8.

It is replaced with Update Manager. Tracked by EAP7-1917

Local run

```
  TESTS: Homepage
    ✓ Should display About info (9373ms)
    ✓ Should load Deployments page
    ✓ Should load Configuration page
    ✓ Should load Runtime page
Stopping container for test test_homepage
    ✓ Should load Access Control page


  5 passing (14s)

[mochawesome] Report JSON saved to /home/mchoma/git-repo/berg/packages/testsuite/results/cypress/e2e/test-homepage_pass.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        5                                                                                │
  │ Passing:      5                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     13 seconds                                                                       │
  │ Spec Ran:     test-homepage.cy.ts                                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  test-homepage.cy.ts                      00:13        5        5        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:13        5        5        -        -        -  

```