### PR TITLE
GH action on Pull Request

### DIFF
--- a/.github/workflows/on-pull-request-workflow.yaml
+++ b/.github/workflows/on-pull-request-workflow.yaml
@@ -1,0 +1,24 @@
+name: On PR
+on:
+  pull_request:
+    types: [opened,synchronize,edited]
+jobs:
+  verify-codebase:
+    name: "Verify codebase"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout project"
+        uses: actions/checkout@v3
+      - name: "Setup NodeJS"
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: "Setup JDK"
+        uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "17"
+      - run: npm install
+      - run: npm run lint
+      - run: npm run compile
+

--- a/.github/workflows/on-pull-request-workflow.yaml
+++ b/.github/workflows/on-pull-request-workflow.yaml
@@ -19,6 +19,6 @@ jobs:
           distribution: "adopt"
           java-version: "17"
       - run: npm install
-      - run: npm run lint
       - run: npm run compile
+      - run: npm run lint
 


### PR DESCRIPTION
This PR adds GH action CI workflow on opened pull request. This action performs `npm run lint` and `npm run compile` to make sure the submitted code is compilable and doesn't contain errors captured via `npm run lint`
