### PR TITLE
Change settings of mount to be visible from container

### DIFF
--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
                 {
                   source: __dirname + "/cypress/fixtures",
                   target: "/home/fixtures",
+                  mode: "z",
                 },
               ])
               .withWaitStrategy(Wait.forLogMessage(new RegExp(".*(WildFly Full.*|JBoss EAP.*)started in.*")))


### PR DESCRIPTION
Tried [`z` mode](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label) option and it works. 

Local run of all tests using mount folder  `/home/fixtures`

```
  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  core-management/test-configuration-      00:22        2        2        -        -        - │
  │    subsystem-core-management-process-s                                                         │
  │    tate-listener.cy.ts                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  datasource/test-configuration-datas      00:57        7        7        -        -        - │
  │    ource-mariadb-finder.cy.ts                                                                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  datasource/test-configuration-datas      01:06        7        7        -        -        - │
  │    ource-mysql-finder.cy.ts                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  datasource/test-configuration-datas      01:40        7        7        -        -        - │
  │    ource-postgre-finder.cy.ts                                                                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  datasource/test-configuration-datas      00:30        1        1        -        -        - │
  │    ource-postgre.cy.ts                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  datasource/test-configuration-datas      01:02        7        7        -        -        - │
  │    ource-sqlserver-finder.cy.ts                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        05:40       31       31        -        -        -  

```