### PR TITLE
Use nightly wildfly as we use nightly HAL.

### DIFF
--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       on("task", {
         "start:wildfly:container": ({ name, configuration }) => {
           return new Promise((resolve, reject) => {
-            new GenericContainer(process.env.WILDFLY_IMAGE || "quay.io/halconsole/wildfly:latest")
+            new GenericContainer(process.env.WILDFLY_IMAGE || "quay.io/halconsole/wildfly-development:latest")
               .withName(name as string)
               .withNetworkMode(config.env.NETWORK_NAME as string)
               .withNetworkAliases("wildfly")

--- a/packages/testsuite/cypress/e2e/deployment-scanner/test-configuration-subsystem-deployment-scanner.cy.ts
+++ b/packages/testsuite/cypress/e2e/deployment-scanner/test-configuration-subsystem-deployment-scanner.cy.ts
@@ -152,7 +152,12 @@ describe("TESTS: Configuration => Subsystem => Deployment Scanner", () => {
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, relativeTo, "jboss.server.base.dir");
     cy.saveForm(configurationFormId);
-    cy.verifyAttribute(managementEndpoint, address.concat(deploymentScanners.update.name), relativeTo, "jboss.server.base.dir");
+    cy.verifyAttribute(
+      managementEndpoint,
+      address.concat(deploymentScanners.update.name),
+      relativeTo,
+      "jboss.server.base.dir"
+    );
   });
 
   it("Toggle runtime-failure-causes-rollback", () => {


### PR DESCRIPTION
Previous version was lagging to much

Local run:
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  test-configuration-subsystem-core-m      00:20        2        2        -        -        - │
  │    anagement-process-state-listener.cy                                                         │
  │    .ts                                                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:20        2        2        -        -        -  

```