### PR TITLE
Introduce usage of AlwaysPullPolicy when pulling images

### DIFF
--- a/packages/berg/src/berg.ts
+++ b/packages/berg/src/berg.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, Network, StartedNetwork, StartedTestContainer } from "testcontainers";
+import { AlwaysPullPolicy, GenericContainer, Network, StartedNetwork, StartedTestContainer } from "testcontainers";
 
 export class Berg {
   private static _instance: Berg;
@@ -17,6 +17,7 @@ export class Berg {
       const halContainer = await new GenericContainer(
         process.env.HAL_IMAGE || "quay.io/halconsole/hal-development:latest"
       )
+        .withPullPolicy(new AlwaysPullPolicy())
         .withExposedPorts(9090)
         .withNetworkMode(network.getName())
         .withNetworkAliases("hal")

--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { defineConfig } from "cypress";
-import { GenericContainer, StartedTestContainer, StoppedTestContainer, Wait } from "testcontainers";
+import { AlwaysPullPolicy, GenericContainer, StartedTestContainer, StoppedTestContainer, Wait } from "testcontainers";
 import { Environment } from "testcontainers/dist/src/docker/types";
 
 export default defineConfig({
@@ -16,6 +16,7 @@ export default defineConfig({
         "start:wildfly:container": ({ name, configuration }) => {
           return new Promise((resolve, reject) => {
             new GenericContainer(process.env.WILDFLY_IMAGE || "quay.io/halconsole/wildfly-development:latest")
+              .withPullPolicy(new AlwaysPullPolicy())
               .withName(name as string)
               .withNetworkMode(config.env.NETWORK_NAME as string)
               .withNetworkAliases("wildfly")
@@ -74,6 +75,7 @@ export default defineConfig({
         },
         "start:postgres:container": ({ name, environmentProperties }) => {
           const postgreContainerBuilder = new GenericContainer("postgres")
+            .withPullPolicy(new AlwaysPullPolicy())
             .withName(name as string)
             .withNetworkAliases(name as string)
             .withNetworkMode(config.env.NETWORK_NAME as string)
@@ -98,6 +100,7 @@ export default defineConfig({
         },
         "start:mysql:container": ({ name, environmentProperties }) => {
           const mysqlContainerBuilder = new GenericContainer("mysql")
+            .withPullPolicy(new AlwaysPullPolicy())
             .withName(name as string)
             .withNetworkAliases(name as string)
             .withExposedPorts(3306)
@@ -121,6 +124,7 @@ export default defineConfig({
         },
         "start:mariadb:container": ({ name, environmentProperties }) => {
           const mariadbContainerBuilder = new GenericContainer("mariadb")
+            .withPullPolicy(new AlwaysPullPolicy())
             .withName(name as string)
             .withNetworkAliases(name as string)
             .withExposedPorts(3306)
@@ -143,6 +147,7 @@ export default defineConfig({
         },
         "start:sqlserver:container": ({ name, environmentProperties }) => {
           const sqlserverContainerBuilder = new GenericContainer("mcr.microsoft.com/mssql/server:2022-latest")
+            .withPullPolicy(new AlwaysPullPolicy())
             .withName(name as string)
             .withNetworkAliases(name as string)
             .withNetworkMode(config.env.NETWORK_NAME as string)


### PR DESCRIPTION
To avoid undeterministic behaviour.
Details in https://java.testcontainers.org/features/advanced_options/

Local run
```
npm test -- --browser=chrome --specs="cypress/e2e/datasource/test-configuration-datasource-*.cy.ts"
...
 ====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  test-configuration-datasource-maria      00:55        7        7        -        -        - │
  │    db-finder.cy.ts                                                                             │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  test-configuration-datasource-mysql      01:06        7        7        -        -        - │
  │    -finder.cy.ts                                                                               │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  test-configuration-datasource-postg      00:53        7        7        -        -        - │
  │    re-finder.cy.ts                                                                             │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  test-configuration-datasource-postg      00:32        1        1        -        -        - │
  │    re.cy.ts                                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  test-configuration-datasource-sqlse      00:59        7        7        -        -        - │
  │    rver-finder.cy.ts                                                                           │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        04:27       29       29        -        -        -  

```