### PR TITLE
Add security manager subsystem tests coverage

### DIFF
--- a/.github/workflows/manual-test-matrix-workflow.yaml
+++ b/.github/workflows/manual-test-matrix-workflow.yaml
@@ -28,6 +28,7 @@ jobs:
             "mail",
             "metrics",
             "runtime",
+            "security-manager",
             "system-property",
             "weld",
             "homepage",

--- a/.github/workflows/scheduled-run-all-tests-workflow.yaml
+++ b/.github/workflows/scheduled-run-all-tests-workflow.yaml
@@ -30,6 +30,7 @@ jobs:
             "mail",
             "metrics",
             "runtime",
+            "security-manager",
             "system-property",
             "weld",
             "homepage",

--- a/packages/testsuite/cypress/e2e/security-manager/test-configuration-subsystem-security-manager-maximum-permissions.cy.ts
+++ b/packages/testsuite/cypress/e2e/security-manager/test-configuration-subsystem-security-manager-maximum-permissions.cy.ts
@@ -1,0 +1,113 @@
+describe("TESTS: Configuration => Subsystem => Security Manager => Maximum Permissions", () => {
+  const address = ["subsystem", "security-manager", "deployment-permissions", "default"];
+
+  const maximumPermissionsNavItem = "#sm-max-permissions-item";
+  const maximumPermissionsTableId = "sm-max-permissions-table";
+  const maximumPermissionsForm = "sm-max-permissions-form";
+  const maximumPermissionsAddWizardFormId = "sm-max-permissions-add";
+  const maximumPermissionsClass = "java.io.FilePermission";
+  const maximumPermissionsToDeleteClass = "java.security.AllPermission";
+  const maximumPermissionsAttrubuteName = "maximum-permissions";
+
+  let managementEndpoint: string;
+
+  const maximumPermissions = {
+    create: {
+      class: maximumPermissionsClass,
+      name: "/tmp/create",
+      actions: "read, write",
+    },
+    update: {
+      class: maximumPermissionsClass + "-updated",
+      name: "/tmp/update",
+      actions: "read",
+    },
+    delete: {
+      class: maximumPermissionsToDeleteClass,
+    },
+  };
+
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  beforeEach(() => {
+    cy.navigateTo(managementEndpoint, "security-manager");
+    cy.get(maximumPermissionsNavItem).click();
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Delete default Maximum Permissions", () => {
+    cy.verifyListAttributeContains(
+      managementEndpoint,
+      address,
+      maximumPermissionsAttrubuteName,
+      maximumPermissions.delete
+    );
+    cy.removeFromTable(maximumPermissionsTableId, maximumPermissions.delete.class);
+    cy.verifySuccess();
+    cy.verifyRemovedFromTable(maximumPermissionsTableId, maximumPermissions.delete.class);
+    cy.verifyListAttributeDoesNotContain(
+      managementEndpoint,
+      address,
+      maximumPermissionsAttrubuteName,
+      maximumPermissions.delete
+    );
+  });
+
+  it("Try to create Maximum Permissions", () => {
+    cy.addInTable(maximumPermissionsTableId);
+    cy.text(maximumPermissionsAddWizardFormId, "name", maximumPermissions.create.name);
+    cy.text(maximumPermissionsAddWizardFormId, "actions", maximumPermissions.create.actions);
+    cy.confirmAddResourceWizard();
+    cy.verifyElementHasClass(maximumPermissionsAddWizardFormId, "class", "div", "has-error");
+    cy.closeWizard();
+  });
+
+  it("Create Maximum Permissions", () => {
+    cy.addInTable(maximumPermissionsTableId);
+    cy.text(maximumPermissionsAddWizardFormId, "class", maximumPermissions.create.class);
+    cy.text(maximumPermissionsAddWizardFormId, "name", maximumPermissions.create.name);
+    cy.text(maximumPermissionsAddWizardFormId, "actions", maximumPermissions.create.actions);
+    cy.confirmAddResourceWizard();
+    cy.verifySuccess();
+    cy.verifyListAttributeContains(
+      managementEndpoint,
+      address,
+      maximumPermissionsAttrubuteName,
+      maximumPermissions.create
+    );
+  });
+
+  it("Try to update Maximum Permissions", () => {
+    cy.get("#" + maximumPermissionsTableId + " tbody tr.odd td.sorting_1").click();
+    cy.editForm(maximumPermissionsForm);
+    cy.text(maximumPermissionsForm, "name", maximumPermissions.update.name);
+    cy.text(maximumPermissionsForm, "actions", maximumPermissions.update.actions);
+    cy.clearAttribute(maximumPermissionsForm, "class");
+    cy.saveForm(maximumPermissionsForm);
+    cy.verifyElementHasClass(maximumPermissionsForm, "class", "div", "has-error");
+    cy.cancelForm(maximumPermissionsForm);
+  });
+
+  it("Update Maximum Permissions", () => {
+    cy.get("#" + maximumPermissionsTableId + " tbody tr.odd td.sorting_1").click();
+    cy.editForm(maximumPermissionsForm);
+    cy.text(maximumPermissionsForm, "class", maximumPermissions.update.class);
+    cy.text(maximumPermissionsForm, "name", maximumPermissions.update.name);
+    cy.text(maximumPermissionsForm, "actions", maximumPermissions.update.actions);
+    cy.saveForm(maximumPermissionsForm);
+    cy.verifySuccess();
+    cy.verifyListAttributeContains(
+      managementEndpoint,
+      address,
+      maximumPermissionsAttrubuteName,
+      maximumPermissions.update
+    );
+  });
+});

--- a/packages/testsuite/cypress/e2e/security-manager/test-configuration-subsystem-security-manager-minimum-permissions.cy.ts
+++ b/packages/testsuite/cypress/e2e/security-manager/test-configuration-subsystem-security-manager-minimum-permissions.cy.ts
@@ -1,0 +1,126 @@
+describe("TESTS: Configuration => Subsystem => Security Manager => Minimum Permissions", () => {
+  const address = ["subsystem", "security-manager", "deployment-permissions", "default"];
+
+  const mininumPermissionsTableId = "sm-min-permissions-table";
+  const mininumPermissionsForm = "sm-min-permissions-form";
+  const mininumPermissionsAddWizardFormId = "sm-min-permissions-add";
+  const mininumPermissionsClass = "java.io.FilePermission";
+  const mininumPermissionsToDeleteClass = "java.util.PropertyPermission";
+  const mininumPermissionsAttrubuteName = "minimum-permissions";
+
+  let managementEndpoint: string;
+
+  const mininumPermissions = {
+    create: {
+      class: mininumPermissionsClass,
+      name: "/tmp/create",
+      actions: "read, write",
+    },
+    update: {
+      class: mininumPermissionsClass + "-updated",
+      name: "/tmp/update",
+      actions: "read",
+    },
+    delete: {
+      class: mininumPermissionsToDeleteClass,
+      name: "property-to-delete",
+      actions: "read, write",
+    },
+  };
+
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+      cy.task("execute:cli", {
+        operation: "write-attribute",
+        managementApi: `${managementEndpoint}/management`,
+        address: address,
+        name: mininumPermissionsAttrubuteName,
+        value: [
+          {
+            class: mininumPermissions.delete.class,
+            name: mininumPermissions.delete.name,
+            actions: mininumPermissions.delete.actions,
+          },
+        ],
+      });
+    });
+  });
+
+  beforeEach(() => {
+    cy.navigateTo(managementEndpoint, "security-manager");
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Try to create Minimum Permissions", () => {
+    cy.addInTable(mininumPermissionsTableId);
+    cy.text(mininumPermissionsAddWizardFormId, "name", mininumPermissions.create.name);
+    cy.text(mininumPermissionsAddWizardFormId, "actions", mininumPermissions.create.actions);
+    cy.confirmAddResourceWizard();
+    cy.verifyElementHasClass(mininumPermissionsAddWizardFormId, "class", "div", "has-error");
+    cy.closeWizard();
+  });
+
+  it("Create Minimum Permissions", () => {
+    cy.addInTable(mininumPermissionsTableId);
+    cy.text(mininumPermissionsAddWizardFormId, "class", mininumPermissions.create.class);
+    cy.text(mininumPermissionsAddWizardFormId, "name", mininumPermissions.create.name);
+    cy.text(mininumPermissionsAddWizardFormId, "actions", mininumPermissions.create.actions);
+    cy.confirmAddResourceWizard();
+    cy.verifySuccess();
+    cy.verifyListAttributeContains(
+      managementEndpoint,
+      address,
+      mininumPermissionsAttrubuteName,
+      mininumPermissions.create
+    );
+  });
+
+  it("Try to update Minimum Permissions", () => {
+    cy.get("#" + mininumPermissionsTableId + " tbody tr.odd td.sorting_1").click();
+    cy.editForm(mininumPermissionsForm);
+    cy.text(mininumPermissionsForm, "name", mininumPermissions.update.name);
+    cy.text(mininumPermissionsForm, "actions", mininumPermissions.update.actions);
+    cy.clearAttribute(mininumPermissionsForm, "class");
+    cy.saveForm(mininumPermissionsForm);
+    cy.verifyElementHasClass(mininumPermissionsForm, "class", "div", "has-error");
+    cy.cancelForm(mininumPermissionsForm);
+  });
+
+  it("Update Minimum Permissions", () => {
+    cy.get("#" + mininumPermissionsTableId + " tbody tr.odd td.sorting_1").click();
+    cy.editForm(mininumPermissionsForm);
+    cy.text(mininumPermissionsForm, "class", mininumPermissions.update.class);
+    cy.text(mininumPermissionsForm, "name", mininumPermissions.update.name);
+    cy.text(mininumPermissionsForm, "actions", mininumPermissions.update.actions);
+    cy.saveForm(mininumPermissionsForm);
+    cy.verifySuccess();
+    cy.verifyListAttributeContains(
+      managementEndpoint,
+      address,
+      mininumPermissionsAttrubuteName,
+      mininumPermissions.update
+    );
+  });
+
+  it("Delete Minimum Permissions", () => {
+    cy.verifyListAttributeContains(
+      managementEndpoint,
+      address,
+      mininumPermissionsAttrubuteName,
+      mininumPermissions.delete
+    );
+    cy.removeFromTable(mininumPermissionsTableId, mininumPermissions.delete.class);
+    cy.verifySuccess();
+    cy.verifyRemovedFromTable(mininumPermissionsTableId, mininumPermissions.delete.class);
+    cy.verifyListAttributeDoesNotContain(
+      managementEndpoint,
+      address,
+      mininumPermissionsAttrubuteName,
+      mininumPermissions.delete
+    );
+  });
+});

--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -10,6 +10,11 @@ Cypress.Commands.add("saveForm", (formId) => {
   cy.get(saveButton).scrollIntoView().click();
 });
 
+Cypress.Commands.add("cancelForm", (formId) => {
+  const saveButton = "#" + formId + '-editing button.btn.btn-hal.btn-default:contains("Cancel")';
+  cy.get(saveButton).scrollIntoView().click();
+});
+
 Cypress.Commands.add("resetForm", (formId, managementApi, address) => {
   const resetButton = "#" + formId + ' a.clickable[data-operation="reset"';
   cy.get(resetButton).click();
@@ -159,6 +164,13 @@ declare global {
        * @param address - Indexes contains values between "/" from request address.
        */
       resetForm(formId: string, managementApi: string, address: string[]): Chainable<void>;
+      /**
+       * Click on "Cancel" for cancelling editing mode.
+       * @category Form Editing
+       *
+       * @param formId - The ID of section which need to be canceled.
+       */
+      cancelForm(formId: string): Chainable<void>;
       /**
        * Click on "Help" button to show documentation for attributes on editing form
        * @category Form Editing

--- a/packages/testsuite/cypress/support/navigation.ts
+++ b/packages/testsuite/cypress/support/navigation.ts
@@ -25,6 +25,10 @@ Cypress.Commands.add("confirmAddResourceWizard", () => {
   cy.get('div.modal-footer > button.btn.btn-hal.btn-primary:contains("Add")').click({ force: true });
 });
 
+Cypress.Commands.add("closeWizard", () => {
+  cy.get("div.modal-header > button.close >").click({ force: true, multiple: true });
+});
+
 Cypress.Commands.add("confirmNextInWizard", () => {
   cy.get('div.modal-footer > button.btn.btn-primary:contains("Next")').click({ force: true });
 });
@@ -83,6 +87,11 @@ declare global {
       confirmAddResourceWizard(): void;
       /**
        * Confirm the next resource dialog
+       * @category Navigation
+       */
+      closeWizard(): void;
+      /**
+       * Close the dialog
        * @category Navigation
        */
       confirmNextInWizard(): void;

--- a/packages/testsuite/cypress/support/verification-utils.ts
+++ b/packages/testsuite/cypress/support/verification-utils.ts
@@ -4,6 +4,12 @@ Cypress.Commands.add("verifySuccess", () => {
   cy.get(".toast-notifications-list-pf .alert-success").should("be.visible");
 });
 
+Cypress.Commands.add("verifyElementHasClass", (formId, attributeName, elementName, className) => {
+  cy.formInput(formId, attributeName)
+    .get(elementName + "." + className)
+    .should("exist");
+});
+
 Cypress.Commands.add("verifyAttribute", (managementEndpoint, address, attributeName, expectedValue) => {
   cy.task("execute:cli", {
     managementApi: managementEndpoint + "/management",
@@ -69,6 +75,21 @@ declare global {
        * @category Verification
        */
       verifySuccess(): Chainable<void>;
+      /**
+       * Verify the specified HTML element has a specified class.
+       * @category Verification
+       *
+       * @param configurationFormId - The ID of section with the form input.
+       * @param attributeName - name of form input.
+       * @param elementName - Name of HTML element
+       * @param className - Name of class that has to be presented in the HTML element
+       */
+      verifyElementHasClass(
+        formId: string,
+        attributeName: string,
+        elementName: string,
+        className: string
+      ): Chainable<void>;
       /**
        * Verify the specific configuration is saved.
        * @category Verification


### PR DESCRIPTION
Jira: [EAPQE-83](https://issues.redhat.com/browse/EAPQE-83)
Berg issue: #9 

Security Manager subsystem page contains "minimum permissions" and "maximum permissions" vertical navigation items, expecting two spec files to be created.

Resources to cover (from `/subsystem=securitymanager:read-resource(recursive=true)`):

- [X]  /subsystem=security-manager/deployment-permissions=default/minimum-permissions
- [X]  /subsystem=security-manager/deployment-permissions=default/minimum-permissions/actions
- [X]  /subsystem=security-manager/deployment-permissions=default/minimum-permissions/class
- [X]  /subsystem=security-manager/deployment-permissions=default/minimum-permissions/module
- [X]  /subsystem=security-manager/deployment-permissions=default/minimum-permissions/name
- [X]  /subsystem=security-manager/deployment-permissions=default/maximum-permissions
- [X]  /subsystem=security-manager/deployment-permissions=default/maximum-permissions/actions
- [X]  /subsystem=security-manager/deployment-permissions=default/maximum-permissions/class
- [X]  /subsystem=security-manager/deployment-permissions=default/maximum-permissions/module
- [X]  /subsystem=security-manager/deployment-permissions=default/maximum-permissions/name