### PR TITLE
[EAPQE-82][hal#34] Add transactions subsystem test coverage

### DIFF
--- a/.github/workflows/manual-test-matrix-workflow.yaml
+++ b/.github/workflows/manual-test-matrix-workflow.yaml
@@ -29,6 +29,7 @@ jobs:
             "metrics",
             "runtime",
             "system-property",
+            "transaction",
             "weld",
             "homepage",
             "smoke",

--- a/.github/workflows/scheduled-run-all-tests-workflow.yaml
+++ b/.github/workflows/scheduled-run-all-tests-workflow.yaml
@@ -31,6 +31,7 @@ jobs:
             "metrics",
             "runtime",
             "system-property",
+            "transaction",
             "weld",
             "homepage",
             "smoke",

--- a/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-configuration.cy.ts
+++ b/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-configuration.cy.ts
@@ -1,0 +1,128 @@
+// navigation crumbs in the management console
+describe("TESTS: Configuration => Sybsystem => Transaction => Configuration", () => {
+  const transactions = "transactions";
+  const address = ["subsystem", transactions];
+  const configTab = "#tx-attributes-config-item";
+  const configurationForm = "tx-attributes-form";
+  const defaultTimeout = "default-timeout";
+  const enableTsmStatus = "enable-tsm-status";
+  const journalStoreEnableAIO = "journal-store-enable-async-io";
+  const jts = "jts";
+  const maximumTimeout = "maximum-timeout";
+  const nodeIdentifier = "node-identifier";
+  const statisticsEnabled = "statistics-enabled";
+  const useJurnalStore = "use-journal-store";
+
+  let managementEndpoint: string;
+
+  // Here we start our WildFly container prior to test execution
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Edit Default Timeout", () => {
+    cy.readAttributeAsNumber(managementEndpoint, address, defaultTimeout).then((defaultValue: number) => {
+      const newValue = defaultValue + 42;
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(configTab).click();
+      cy.editForm(configurationForm);
+      cy.text(configurationForm, defaultTimeout, newValue);
+      cy.saveForm(configurationForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, defaultTimeout, newValue);
+    });
+  });
+
+  it("Toggle Enable Tsm Status", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, enableTsmStatus).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(configTab).click();
+      cy.editForm(configurationForm);
+      cy.flip(configurationForm, enableTsmStatus, defaultValue);
+      cy.saveForm(configurationForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, enableTsmStatus, !defaultValue);
+    });
+  });
+
+  it("Toggle Journal Store Enable Async IO", () => {
+    cy.writeAttrubute(managementEndpoint, address, useJurnalStore, true);
+    cy.readAttributeAsBoolean(managementEndpoint, address, journalStoreEnableAIO).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(configTab).click();
+      cy.editForm(configurationForm);
+      cy.flip(configurationForm, journalStoreEnableAIO, defaultValue);
+      cy.saveForm(configurationForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, journalStoreEnableAIO, !defaultValue);
+    });
+  });
+
+  it("Toggle JTS", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, jts).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(configTab).click();
+      cy.editForm(configurationForm);
+      cy.flip(configurationForm, jts, defaultValue);
+      cy.saveForm(configurationForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, jts, !defaultValue);
+    });
+  });
+
+  it("Edit Maximum Timeout", () => {
+    cy.readAttributeAsNumber(managementEndpoint, address, maximumTimeout).then((defaultValue: number) => {
+      const newValue = defaultValue + 100;
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(configTab).click();
+      cy.editForm(configurationForm);
+      cy.text(configurationForm, maximumTimeout, newValue);
+      cy.saveForm(configurationForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, maximumTimeout, newValue);
+    });
+  });
+
+  it("Edit Node Identifier", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(configTab).click();
+    cy.editForm(configurationForm);
+    cy.text(configurationForm, nodeIdentifier, "updated-node-identifier");
+    cy.saveForm(configurationForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, nodeIdentifier, "updated-node-identifier");
+  });
+
+  it("Toggle Statistics enabled", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(configTab).click();
+    cy.editForm(configurationForm);
+    cy.get("[data-form-item-group='tx-attributes-form-statistics-enabled-editing']")
+      .find(".expression-mode-switcher")
+      .filter("[title='Switch to normal mode']")
+      .click();
+    cy.flip(configurationForm, statisticsEnabled, false);
+    cy.saveForm(configurationForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, statisticsEnabled, true);
+  });
+
+  it("Toggle Use Jurnal Store", () => {
+    cy.writeAttrubute(managementEndpoint, address, journalStoreEnableAIO, false);
+    cy.readAttributeAsBoolean(managementEndpoint, address, useJurnalStore).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(configTab).click();
+      cy.editForm(configurationForm);
+      cy.flip(configurationForm, useJurnalStore, defaultValue);
+      cy.saveForm(configurationForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, useJurnalStore, !defaultValue);
+    });
+  });
+});

--- a/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-finder.cy.ts
+++ b/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-finder.cy.ts
@@ -1,0 +1,22 @@
+describe("TESTS: Configuration => Sybsystem => Transaction", () => {
+  let managementEndpoint: string;
+
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Get to Transaction Subsystem from homepage", () => {
+    cy.visit(`?connect=${managementEndpoint}`);
+    cy.get("#tlc-configuration").click();
+    cy.get("#subsystems").click();
+    cy.get("#transactions").click();
+    cy.get("#transactions").find(".btn").click();
+    cy.url().should("include", "transactions");
+  });
+});

--- a/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-jdbc.cy.ts
+++ b/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-jdbc.cy.ts
@@ -1,0 +1,164 @@
+import { AddDataSourceBuilder } from "@berg/commands";
+
+// navigation crumbs in the management console
+describe("TESTS: Configuration => Sybsystem => Transaction => Path", () => {
+  const transactions = "transactions";
+  const address = ["subsystem", transactions];
+  const jdbcTab = "#tx-jdbc-config-item";
+  const jdbcForm = "tx-jdbc-form";
+
+  const useJdbcStore = "use-jdbc-store";
+  const jdbcActionStoreDropTable = "jdbc-action-store-drop-table";
+  const jdbcActionStoreTablePrefix = "jdbc-action-store-table-prefix";
+  const jdbcComStoreDropTable = "jdbc-communication-store-drop-table";
+  const jdbcComStoreTablePrefix = "jdbc-communication-store-table-prefix";
+  const jdbcStateStoreDropTable = "jdbc-state-store-drop-table";
+  const jdbcStateStoreTablePrefix = "jdbc-state-store-table-prefix";
+  const jdbcStoreDatasource = "jdbc-store-datasource";
+
+  let managementEndpoint: string;
+
+  const datasourceBase = {
+    connectionUrl:
+      "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}",
+    driverName: "h2",
+  };
+
+  const nonEmptyDS = {
+    ...datasourceBase,
+    name: "nonEmptyDS",
+    jndiName: "java:jboss/datasources/nonEmptyDS,",
+  };
+
+  const nonEmptyDSUpdated = {
+    ...datasourceBase,
+    name: "nonEmptyDS",
+    jndiName: "java:jboss/datasources/nonEmptyDS,",
+  };
+
+  // Here we start our WildFly container prior to test execution
+  before(() => {
+    cy.startWildflyContainer()
+      .then((result) => {
+        managementEndpoint = result as string;
+      })
+      .then(() => {
+        cy.executeInWildflyContainer(
+          new AddDataSourceBuilder()
+            .withName(nonEmptyDS.name)
+            .withJndiName(nonEmptyDS.jndiName)
+            .withConnectionUrl(nonEmptyDS.connectionUrl)
+            .withDriverName(nonEmptyDS.driverName)
+            .build()
+            .toCLICommand()
+        );
+        cy.executeInWildflyContainer(
+          new AddDataSourceBuilder()
+            .withName(nonEmptyDSUpdated.name)
+            .withJndiName(nonEmptyDSUpdated.jndiName)
+            .withConnectionUrl(nonEmptyDSUpdated.connectionUrl)
+            .withDriverName(nonEmptyDSUpdated.driverName)
+            .build()
+            .toCLICommand()
+        );
+      });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Edit JDBC Store Datasource", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(jdbcTab).click();
+    cy.editForm(jdbcForm);
+    cy.text(jdbcForm, jdbcStoreDatasource, nonEmptyDSUpdated.name);
+    cy.saveForm(jdbcForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, jdbcStoreDatasource, nonEmptyDSUpdated.name);
+  });
+
+  it("Toggle Use JDBC Store", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, useJdbcStore).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(jdbcTab).click();
+      cy.editForm(jdbcForm);
+
+      //When use-jdbc-store toggled to true, it needs jdbc-datasource to be set
+      if (!defaultValue) {
+        cy.text(jdbcForm, jdbcStoreDatasource, nonEmptyDS.name);
+      }
+
+      cy.flip(jdbcForm, useJdbcStore, defaultValue);
+      cy.saveForm(jdbcForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, useJdbcStore, !defaultValue);
+    });
+  });
+
+  it("Toggle JDBC Action Store Drop Table", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, jdbcActionStoreDropTable).then((defaultValue: boolean) => {
+      toggleWithUseJDBCStore(jdbcActionStoreDropTable, defaultValue);
+    });
+  });
+
+  it("Edit JDBC Action Store Table Prefix", () => {
+    editWithUseJDBCStore(jdbcActionStoreTablePrefix, "updatedPrefix");
+  });
+
+  it("Toggle JDBC Communication Store Drop Table", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, jdbcComStoreDropTable).then((defaultValue: boolean) => {
+      toggleWithUseJDBCStore(jdbcComStoreDropTable, defaultValue);
+    });
+  });
+
+  it("Edit JDBC Communication Store Table Prefix", () => {
+    editWithUseJDBCStore(jdbcStateStoreTablePrefix, "updatedPrefix");
+  });
+
+  it("Toggle JDBC State Store Drop Table", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, jdbcStateStoreDropTable).then((defaultValue: boolean) => {
+      toggleWithUseJDBCStore(jdbcStateStoreDropTable, defaultValue);
+    });
+  });
+
+  it("Edit JDBC State Store Table Prefix", () => {
+    editWithUseJDBCStore(jdbcComStoreTablePrefix, "updatedPrefix");
+  });
+
+  const toggleWithUseJDBCStore = (attributeName: string, value: boolean) => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, useJdbcStore).then((useJdbcStoreValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(jdbcTab).click();
+      cy.editForm(jdbcForm);
+
+      if (!useJdbcStoreValue) {
+        cy.text(jdbcForm, jdbcStoreDatasource, nonEmptyDS.name);
+        cy.flip(jdbcForm, useJdbcStore, useJdbcStoreValue);
+      }
+
+      cy.flip(jdbcForm, attributeName, value);
+      cy.saveForm(jdbcForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, attributeName, !value);
+    });
+  };
+
+  const editWithUseJDBCStore = (attributeName: string, value: string) => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, useJdbcStore).then((useJdbcStoreValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(jdbcTab).click();
+      cy.editForm(jdbcForm);
+
+      if (!useJdbcStoreValue) {
+        cy.text(jdbcForm, jdbcStoreDatasource, nonEmptyDS.name);
+        cy.flip(jdbcForm, useJdbcStore, useJdbcStoreValue);
+      }
+
+      cy.text(jdbcForm, attributeName, value);
+      cy.saveForm(jdbcForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, attributeName, value);
+    });
+  };
+});

--- a/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-path.cy.ts
+++ b/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-path.cy.ts
@@ -1,0 +1,42 @@
+// navigation crumbs in the management console
+describe("TESTS: Configuration => Sybsystem => Transaction => Path", () => {
+  const transactions = "transactions";
+  const address = ["subsystem", transactions];
+  const pathTab = "#tx-path-config-item";
+  const pathForm = "tx-path-form";
+  const objectStorePath = "object-store-path";
+  const objectStoreRelativeTo = "object-store-relative-to";
+
+  let managementEndpoint: string;
+
+  // Here we start our WildFly container prior to test execution
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Edit Object Store Path", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(pathTab).click();
+    cy.editForm(pathForm);
+    cy.text(pathForm, objectStorePath, "updated-object-store-path");
+    cy.saveForm(pathForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, objectStorePath, "updated-object-store-path");
+  });
+
+  it("Edit Object Store Relative To", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(pathTab).click();
+    cy.editForm(pathForm);
+    cy.text(pathForm, objectStoreRelativeTo, "updated-object-store-relative-to");
+    cy.saveForm(pathForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, objectStoreRelativeTo, "updated-object-store-relative-to");
+  });
+});

--- a/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-process.cy.ts
+++ b/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-process.cy.ts
@@ -1,0 +1,79 @@
+// navigation crumbs in the management console
+describe("TESTS: Configuration => Sybsystem => Transaction => Process", () => {
+  const transactions = "transactions";
+  const address = ["subsystem", transactions];
+  const processTab = "#tx-process-item";
+  const processForm = "tx-process-form";
+  const processIdUuid = "process-id-uuid";
+  const processIdSocektBinding = "process-id-socket-binding";
+  const processIdSocketMaxPorts = "process-id-socket-max-ports";
+
+  let managementEndpoint: string;
+
+  // Here we start our WildFly container prior to test execution
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Toggle Process ID UUID", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, processIdUuid).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(processTab).click();
+      cy.editForm(processForm);
+
+      //process-id-socket-binding must be set if the process-id-uuid is set to false and must be undefined otherweise
+      if (defaultValue) {
+        cy.text(processForm, processIdSocektBinding, "non-empty");
+      } else {
+        cy.text(processForm, processIdSocektBinding, "");
+      }
+
+      cy.flip(processForm, processIdUuid, defaultValue);
+      cy.saveForm(processForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, processIdUuid, !defaultValue);
+    });
+  });
+
+  it("Edit Process ID Socket Binding", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, processIdUuid).then((pidUUIDvalue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(processTab).click();
+      cy.editForm(processForm);
+
+      //process-id-uuid must be false while process-id-socekt-binding is being set
+      if (pidUUIDvalue) {
+        cy.flip(processForm, processIdUuid, pidUUIDvalue);
+      }
+      cy.text(processForm, processIdSocektBinding, "updated-process-binding");
+      cy.saveForm(processForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, processIdSocektBinding, "updated-process-binding");
+    });
+  });
+
+  it("Edit Process ID Socket Max Ports", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, processIdUuid).then((pidUUIDvalue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(processTab).click();
+      cy.editForm(processForm);
+
+      // process-id-socket-max-ports can be set only with conmbination of process-id-socket-binding
+      if (pidUUIDvalue) {
+        cy.flip(processForm, processIdUuid, pidUUIDvalue);
+        cy.text(processForm, processIdSocektBinding, "updated-process-binding");
+      }
+
+      cy.text(processForm, processIdSocketMaxPorts, 42);
+      cy.saveForm(processForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, processIdSocketMaxPorts, 42);
+    });
+  });
+});

--- a/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-recovery.cy.ts
+++ b/packages/testsuite/cypress/e2e/transaction/transactions-configuration-subsystem-transaction-recovery.cy.ts
@@ -1,0 +1,55 @@
+// navigation crumbs in the management console
+describe("TESTS: Configuration => Sybsystem => Transaction => Recovery", () => {
+  const transactions = "transactions";
+  const address = ["subsystem", transactions];
+  const recoveryTab = "#tx-recovery-config-item";
+  const recoveryForm = "tx-recovery-form";
+  const socketBinding = "socket-binding";
+  const statusSocketBinding = "status-socket-binding";
+  const recoveryListener = "recovery-listener";
+
+  let managementEndpoint: string;
+
+  // Here we start our WildFly container prior to test execution
+  before(() => {
+    cy.startWildflyContainer().then((result) => {
+      managementEndpoint = result as string;
+    });
+  });
+
+  after(() => {
+    cy.task("stop:containers");
+  });
+
+  it("Edit Socket Binding", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(recoveryTab).click();
+    cy.editForm(recoveryForm);
+    cy.text(recoveryForm, socketBinding, "updated-socket-binding");
+    cy.saveForm(recoveryForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, socketBinding, "updated-socket-binding");
+  });
+
+  it("Edit Status Socket Binding", () => {
+    cy.navigateTo(managementEndpoint, transactions);
+    cy.get(recoveryTab).click();
+    cy.editForm(recoveryForm);
+    cy.text(recoveryForm, statusSocketBinding, "updated-status-socket-binding");
+    cy.saveForm(recoveryForm);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, statusSocketBinding, "updated-status-socket-binding");
+  });
+
+  it("Toggle Recovery Listener", () => {
+    cy.readAttributeAsBoolean(managementEndpoint, address, recoveryListener).then((defaultValue: boolean) => {
+      cy.navigateTo(managementEndpoint, transactions);
+      cy.get(recoveryTab).click();
+      cy.editForm(recoveryForm);
+      cy.flip(recoveryForm, recoveryListener, defaultValue);
+      cy.saveForm(recoveryForm);
+      cy.verifySuccess();
+      cy.verifyAttribute(managementEndpoint, address, recoveryListener, !defaultValue);
+    });
+  });
+});

--- a/packages/testsuite/cypress/support/resource-utils.ts
+++ b/packages/testsuite/cypress/support/resource-utils.ts
@@ -125,6 +125,16 @@ Cypress.Commands.add("readAttributeAsObjectList", (managementEndpoint, address, 
     });
 });
 
+Cypress.Commands.add("writeAttrubute", (managementEndpoint, address, name, value) => {
+  cy.task("execute:cli", {
+    managementApi: managementEndpoint + "/management",
+    operation: "write-attribute",
+    address: address,
+    name: name,
+    value: value,
+  });
+});
+
 Cypress.Commands.add("formInput", (configurationFormId, attributeName) => {
   return cy.get("#" + configurationFormId + "-" + attributeName + "-editing");
 });
@@ -256,6 +266,19 @@ declare global {
        * @returns The the attribute value of subsystem configuration as generic object.
        */
       readAttributeAsObjectList(managementEndpoint: string, address: string[], name: string): Chainable<object[]>;
+      /**
+       *
+       * @param managementEndpoint - Management endpoint of the WildFly server container instance.
+       * @param address - CLI address of subsystem.
+       * @param name - name of attribute from subsystem configuration.
+       * @param value - value to be set to the attribute
+       */
+      writeAttrubute(
+        managementEndpoint: string,
+        address: string[],
+        name: string,
+        value: string | boolean | number
+      ): Chainable<object[]>;
       /**
        * Get HTML element from form.
        * @category Get value


### PR DESCRIPTION
Possible follow-ups:

- form reset isn't being tested (from my tests it seems that the reset doesn't reset all attributes correctly)
- no coverage for invalid input values
- no coverage for invalid scenario for example when attribute cannot be set without other one
- no coverage for /subsystem=transactions/commit-markable-resource
- no coverage for /subsystem=transactions/log-store

Possible web console issue:

- Reset form doesn't seem to work
- I can't find how to add commit-markable-resource or log store. There is a "expert mode" in which it seems it should be possible to configure these but I can't make it work.
- It's possible to write non existing DS to [jdbc-store-datasource](https://docs.wildfly.org/28/wildscribe/subsystem/transactions/index.html#attr-jdbc-store-datasource) even though it's stated in docs, that it does need to be defined in datasource subsystem (this seem to be possible even in cli)
- in **process**: when setting process-id-uuid from true to false without setting the process-id-socket-binding, NO error is shown and it's possible to save the form, which shouldn't be (this should be revealed by the invalid scenario tests)