### PR TITLE
Increasing default timeout for commands

### DIFF
--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -4,6 +4,7 @@ import { AlwaysPullPolicy, GenericContainer, StartedTestContainer, StoppedTestCo
 import { Environment } from "testcontainers/dist/src/docker/types";
 
 export default defineConfig({
+  defaultCommandTimeout: 16000,
   reporter: require.resolve("cypress-multi-reporters/index.js"),
   reporterOptions: {
     configFile: "reporter-config.json",


### PR DESCRIPTION
There are less timeout failures when increasing the `defaultCommandTimeout` basic config option value (from the default 4 seconds).
