### PR TITLE
iterface doesnt have resetable fields

### DIFF
--- a/packages/testsuite/cypress/e2e/interface/test-configuration-interface.cy.ts
+++ b/packages/testsuite/cypress/e2e/interface/test-configuration-interface.cy.ts
@@ -44,9 +44,4 @@ describe("TESTS: Configuration => Interface", () => {
       cy.verifyAttribute(managementEndpoint, address, anyAddress, !value);
     });
   });
-
-  it("Reset", () => {
-    cy.navigateTo(managementEndpoint, "interface;name=" + interfaceToEdit.name);
-    cy.resetForm(configurationFormId, managementEndpoint, address);
-  });
 });


### PR DESCRIPTION
Remove reset form test because the field are not able to reset.
