### PR TITLE
Adding global workaround for test issues with edit form button

### DIFF
--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -129,11 +129,12 @@ export default defineConfig({
                             if ((response as { data: { result: string } }).data.result == "running") {
                               clearInterval(interval);
                               const wildflyServer = `http://localhost:${wildflyContainer.getMappedPort(9990)}`;
+                              console.log(`WildFly server is ready: ${wildflyServer}`);
                               resolve(wildflyServer);
                             }
                           })
-                          .catch((error) => {
-                            console.log(error);
+                          .catch(() => {
+                            console.log("WildFly server is not ready yet");
                           });
                       }, 500);
                     });

--- a/packages/testsuite/cypress/e2e/elytron/test-configuration-subsystem-elytron-global-settings.cy.ts
+++ b/packages/testsuite/cypress/e2e/elytron/test-configuration-subsystem-elytron-global-settings.cy.ts
@@ -35,8 +35,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
 
   it("Edit default-authentication-context", () => {
     cy.navigateTo(managementEndpoint, "elytron");
-    // this call is just workaround to prevent of occuring JBEAP-25005
-    cy.help();
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, "default-authentication-context", authenticationContextToUpdate);
     cy.saveForm(configurationFormId);
@@ -46,8 +44,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
 
   it("Edit default-ssl-context", () => {
     cy.navigateTo(managementEndpoint, "elytron");
-    // this call is just workaround to prevent of occuring JBEAP-25005
-    cy.help();
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, "default-ssl-context", sslContextToUpdate);
     cy.saveForm(configurationFormId);
@@ -57,8 +53,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
 
   it("Edit disallowed-providers", () => {
     cy.navigateTo(managementEndpoint, "elytron");
-    // this call is just workaround to prevent of occuring JBEAP-25005
-    cy.help();
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, "disallowed-providers", "DisallowedProvider");
     cy.formInput(configurationFormId, "disallowed-providers").type("{enter}").trigger("change");
@@ -69,8 +63,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
 
   it("Edit final-providers", () => {
     cy.navigateTo(managementEndpoint, "elytron");
-    // this call is just workaround to prevent of occuring JBEAP-25005
-    cy.help();
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, "final-providers", providerLoaders.final.name);
     cy.saveForm(configurationFormId);
@@ -80,8 +72,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
 
   it("Edit initial-providers", () => {
     cy.navigateTo(managementEndpoint, "elytron");
-    // this call is just workaround to prevent of occuring JBEAP-25005
-    cy.help();
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, "initial-providers", providerLoaders.initial.name);
     cy.saveForm(configurationFormId);
@@ -99,8 +89,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
     }).then((result) => {
       value = (result as { result: boolean }).result;
       cy.navigateTo(managementEndpoint, "elytron");
-      // this call is just workaround to prevent of occuring JBEAP-25005
-      cy.help();
       cy.editForm(configurationFormId);
       cy.flip(configurationFormId, "register-jaspi-factory", value);
       cy.saveForm(configurationFormId);
@@ -111,8 +99,6 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Global Se
 
   it("Edit security-properties", () => {
     cy.navigateTo(managementEndpoint, "elytron");
-    // this call is just workaround to prevent of occuring JBEAP-25005
-    cy.help();
     cy.editForm(configurationFormId);
     cy.text(configurationFormId, "security-properties", "prop=val");
     cy.formInput(configurationFormId, "security-properties").type("{enter}").trigger("change");

--- a/packages/testsuite/cypress/e2e/jpa/test-configuration-subsystem-jpa.cy.ts
+++ b/packages/testsuite/cypress/e2e/jpa/test-configuration-subsystem-jpa.cy.ts
@@ -15,8 +15,6 @@ describe("TESTS: Configuration => Subsystem => JPA", () => {
 
   it("Edit default-extended-persistence-inheritance", () => {
     cy.navigateTo(managementEndpoint, "jpa-configuration");
-    // this call is just workaround to prevent of occuring JBEAP-25046
-    cy.help();
     cy.editForm(configurationFormId);
     cy.formInput(configurationFormId, "default-extended-persistence-inheritance").select("SHALLOW", { force: true });
     cy.formInput(configurationFormId, "default-extended-persistence-inheritance").trigger("change", { force: true });

--- a/packages/testsuite/cypress/e2e/update-manager/test-configuration-update-channel.cy.ts
+++ b/packages/testsuite/cypress/e2e/update-manager/test-configuration-update-channel.cy.ts
@@ -73,8 +73,6 @@ describe("TESTS: Update Manager => Channels", () => {
 
   it("Update gav channel parameters", () => {
     cy.navigateToSpecificChannel(managementEndpoint, channels.gav.name);
-    // Same workaround as for JBEAP-25005 and JBEAP-25046 when try to edit form the cypress is to fast
-    cy.help();
     cy.editForm(channelForm);
     cy.formInput(channelForm, "repositories")
       .clear()
@@ -87,8 +85,6 @@ describe("TESTS: Update Manager => Channels", () => {
 
   it("Update url channel parameters", () => {
     cy.navigateToSpecificChannel(managementEndpoint, channels.url.name);
-    // Same workaround as for JBEAP-25005 and JBEAP-25046 when try to edit form the cypress is to fast
-    cy.help();
     cy.editForm(channelForm);
     cy.formInput(channelForm, "repositories")
       .clear()

--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -1,7 +1,19 @@
 Cypress.Commands.add("editForm", (formId) => {
-  const editButton = "#" + formId + ' a.clickable[data-operation="edit"';
+  const editButton = "#" + formId + ' a.clickable[data-operation="edit"]';
   cy.get(`#${formId}-editing`).should("not.be.visible");
   cy.get(editButton).click();
+  // Workaround - JBEAP-25005,JBEAP-25046 - the form is sometimes not loaded in time and Cypress is not able to recover
+  // from such state and click the button. Waiting does not help, but multiple manual checks for the visibility
+  // of the button do. Note that the button is clicked just one time (probably) once visible.
+  for (let reClickTry = 0; reClickTry < 2; reClickTry++) {
+    cy.wait(1000);
+    cy.get(editButton).then(($button) => {
+      if ($button.is(":visible")) {
+        cy.get(editButton).click();
+      }
+    });
+  }
+  // workaround - end
   cy.get(`#${formId}-editing`).should("be.visible");
 });
 

--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -5,8 +5,7 @@ Cypress.Commands.add("editForm", (formId) => {
   // Workaround - JBEAP-25005,JBEAP-25046 - the form is sometimes not loaded in time and Cypress is not able to recover
   // from such state and click the button. Waiting does not help, but multiple manual checks for the visibility
   // of the button do. Note that the button is clicked just one time (probably) once visible.
-  for (let reClickTry = 0; reClickTry < 2; reClickTry++) {
-    cy.wait(1000);
+  for (let reClickTry = 0; reClickTry < 5; reClickTry++) {
     cy.get(editButton).then(($button) => {
       if ($button.is(":visible")) {
         cy.get(editButton).click();


### PR DESCRIPTION
- Click on the edit button when is visible, 2 additional attempts.
- Don't log error message when it is verifying status of the Wildfly server

test run main:
https://github.com/kstekovi/berg/actions/runs/5832767352
test run edit-form:
https://github.com/kstekovi/berg/actions/runs/5940463851