### PR TITLE
Update logging of CLI operations

### DIFF
--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -276,6 +276,7 @@ export default defineConfig({
         },
         "execute:in:container": ({ containerName, command }) => {
           return new Promise((resolve, reject) => {
+            console.log(`CLI commands: ${command as string}`);
             const containerToExec = startedContainers.get(containerName as string);
             let managementPort = startedContainersManagementPorts.get(containerName as string);
             managementPort = managementPort ?? 9990;
@@ -288,7 +289,12 @@ export default defineConfig({
                 }`,
               ])
               .then((value) => {
-                resolve(value.output);
+                if (value.exitCode === 0) {
+                  resolve(value);
+                } else {
+                  console.log(value);
+                  reject(value);
+                }
               })
               .catch((err: { response: { data: string } }) => reject(err.response.data));
           });

--- a/packages/testsuite/cypress.config.ts
+++ b/packages/testsuite/cypress.config.ts
@@ -99,7 +99,6 @@ export default defineConfig({
                         });
                     });
                 } else {
-                  startedContainersManagementPorts.set(name as string, wildflyContainer.getMappedPort(9990));
                   const managementApi = `http://localhost:${wildflyContainer.getMappedPort(9990)}/management`;
                   return axios
                     .post(managementApi, {


### PR DESCRIPTION
- Verify the exit code of CLI operation. If the exit code is `0` then resolve the CLI operation. If the exit code isn't `0` then log output and reject the CLI operation. 
- use default `9990` port in case of network mode

nightly run: https://github.com/hal/berg/actions/runs/5994318213
test run: https://github.com/kstekovi/berg/actions/runs/5999872741
