### PR TITLE
remove ee context service reset test

### DIFF
--- a/packages/testsuite/cypress/e2e/ee/test-configuration-subsystem-ee-services-context-service.cy.ts
+++ b/packages/testsuite/cypress/e2e/ee/test-configuration-subsystem-ee-services-context-service.cy.ts
@@ -74,19 +74,6 @@ describe("TESTS: Configuration => Subsystem => EE => Services => Context Service
     );
   });
 
-  it("Reset", () => {
-    cy.navigateTo(managementEndpoint, "ee");
-    cy.get("#ee-services-item").click();
-    cy.get("#ee-service-context-service").click();
-    cy.selectInTable(contextServicesTable, contextServices.reset.name);
-    cy.resetForm(configurationFormId, managementEndpoint, [
-      "subsystem",
-      "ee",
-      "context-service",
-      contextServices.reset.name,
-    ]);
-  });
-
   it("Remove Context Service", () => {
     cy.navigateTo(managementEndpoint, "ee");
     cy.get("#ee-services-item").click();


### PR DESCRIPTION
The EE context service doesn't contain reset button anymore. 
Remove the reset button test. 
