### PR TITLE
[HAL-1968] Add tests for default-*-timer-management attributes of Con…

### DIFF
--- a/packages/testsuite/cypress/e2e/ejb/test-configuration-subsystem-ejb-services-timer.cy.ts
+++ b/packages/testsuite/cypress/e2e/ejb/test-configuration-subsystem-ejb-services-timer.cy.ts
@@ -40,6 +40,18 @@ describe("TESTS: Configuration => Subsystem => EJB => Services => Timer", () => 
     cy.verifyAttribute(managementEndpoint, address, "default-data-store", fileDataStoreToUpdate.name);
   });
 
+  it("Edit default-persistent-timer-management", () => {
+    cy.navigateTo(managementEndpoint, "ejb3-configuration");
+    cy.get("#ejb3-service-item").click();
+    cy.get("#ejb3-service-timer-item").click();
+    cy.editForm(configurationFormId);
+    cy.text(configurationFormId, "default-persistent-timer-management", "transient");
+    cy.clearAttribute(configurationFormId, "default-data-store");
+    cy.saveForm(configurationFormId);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, "default-persistent-timer-management", "transient");
+  });
+
   it("Edit thread-pool-name", () => {
     cy.navigateTo(managementEndpoint, "ejb3-configuration");
     cy.get("#ejb3-service-item").click();
@@ -51,4 +63,15 @@ describe("TESTS: Configuration => Subsystem => EJB => Services => Timer", () => 
     cy.verifyAttribute(managementEndpoint, address, "thread-pool-name", threadPoolToUpdate);
   });
 
+  it("Edit default-transient-timer-management", () => {
+    cy.navigateTo(managementEndpoint, "ejb3-configuration");
+    cy.get("#ejb3-service-item").click();
+    cy.get("#ejb3-service-timer-item").click();
+    cy.editForm(configurationFormId);
+    cy.text(configurationFormId, "default-transient-timer-management", "transient");
+    cy.clearAttribute(configurationFormId, "thread-pool-name");
+    cy.saveForm(configurationFormId);
+    cy.verifySuccess();
+    cy.verifyAttribute(managementEndpoint, address, "default-transient-timer-management", "transient");
+  });
 });


### PR DESCRIPTION
…figuration -> EJB -> Services -> Timer

https://issues.redhat.com/browse/HAL-1968


By default allowed values for both, `default-persistent-timer-management` and `default-transient-timer-management`, are only `persistent` and `transient`. In the test, I blindly chose `transient` for both. I don't even know what these values mean, but I hope it is not important for UI tests. 