### PR TITLE
Fix npm audit vulnerabilities and pin axios to safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript-eslint": "^8.46.1"
   },
   "dependencies": {
-    "axios": "^1.12.2",
+    "axios": "1.13.6",
     "cypress": "15.11.0",
     "portscanner": "^2.2.0",
     "testcontainers": "^11.7.1"

--- a/package.json
+++ b/package.json
@@ -57,5 +57,11 @@
     "cypress": "15.11.0",
     "portscanner": "^2.2.0",
     "testcontainers": "^11.7.1"
+  },
+  "overrides": {
+    "mocha": {
+      "diff": "^8.0.3",
+      "serialize-javascript": "^7.0.5"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Pin axios to exact version 1.13.6 to prevent automatic installation of potentially compromised versions via semver range resolution
- Add npm overrides for mocha transitive dependencies (`diff` and `serialize-javascript`) to resolve all remaining npm audit vulnerabilities
- `diff` overridden to `^8.0.3` (fixes DoS in parsePatch/applyPatch)
- `serialize-javascript` overridden to `^7.0.5` (fixes RCE and CPU exhaustion DoS)
- Result: `npm audit` reports **0 vulnerabilities**

## Test plan
- [ ] Run `npm install` and verify it completes successfully
- [ ] Run `npm audit` and verify 0 vulnerabilities
- [ ] Run existing test suite to ensure no regressions from dependency updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)