### PR TITLE
Improve editForm to wait for data

### DIFF
--- a/packages/testsuite/cypress/e2e/ejb/test-configuration-subsystem-ejb-services-identity.cy.ts
+++ b/packages/testsuite/cypress/e2e/ejb/test-configuration-subsystem-ejb-services-identity.cy.ts
@@ -36,7 +36,7 @@ describe("TESTS: Configuration => Subsystem => EJB => Services => Identity", () 
     cy.navigateTo(managementEndpoint, "ejb3-configuration");
     cy.get("#ejb3-service-item").click();
     cy.get("#ejb3-service-identity-item").click();
-    cy.editForm(configurationFormId);
+    cy.editForm(configurationFormId, { waitForData: false });
     cy.formInput(configurationFormId, "outflow-security-domains")
       .clear()
       .type(`${securityDomainToUpdate}{enter}`)

--- a/packages/testsuite/cypress/e2e/ejb/test-configuration-subsystem-ejb-state-management-cache.cy.ts
+++ b/packages/testsuite/cypress/e2e/ejb/test-configuration-subsystem-ejb-state-management-cache.cy.ts
@@ -100,7 +100,7 @@ describe("TESTS: Configuration => Subsystem => EJB => State Management => Cache"
     cy.get("#ejb3-state-item").click();
     cy.get("#ejb3-cache-item").click();
     cy.selectInTable(cacheTableId, caches.update.name);
-    cy.editForm(configurationFormId);
+    cy.editForm(configurationFormId, { waitForData: false });
     cy.formInput(configurationFormId, "aliases").clear().type("another-alias{enter}").trigger("change");
     cy.saveForm(configurationFormId);
     cy.verifySuccess();
@@ -112,7 +112,7 @@ describe("TESTS: Configuration => Subsystem => EJB => State Management => Cache"
     cy.get("#ejb3-state-item").click();
     cy.get("#ejb3-cache-item").click();
     cy.selectInTable(cacheTableId, caches.update.name);
-    cy.editForm(configurationFormId);
+    cy.editForm(configurationFormId, { waitForData: false });
     cy.text(configurationFormId, "passivation-store", passivations.update.name);
     cy.saveForm(configurationFormId);
     cy.verifySuccess();

--- a/packages/testsuite/cypress/e2e/elytron/test-configuration-subsystem-elytron-provider-http-server-mechanism-factory.cy.ts
+++ b/packages/testsuite/cypress/e2e/elytron/test-configuration-subsystem-elytron-provider-http-server-mechanism-factory.cy.ts
@@ -79,7 +79,7 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Factories
     cy.get("#http-factories-item").click();
     cy.get("#elytron-provider-http-server-mechanism-factory-item").click();
     cy.selectInTable(providerHttpServerMechanismFactoryTableId, providerHttpServiceMechanismFactories.update.name);
-    cy.editForm(configurationFormId);
+    cy.editForm(configurationFormId, { waitForData: false });
     cy.text(configurationFormId, "providers", "pl-to-update");
     cy.saveForm(configurationFormId);
     cy.verifySuccess();

--- a/packages/testsuite/cypress/e2e/elytron/test-configuration-subsystem-elytron-service-loader-http-server-mechanism-factory.cy.ts
+++ b/packages/testsuite/cypress/e2e/elytron/test-configuration-subsystem-elytron-service-loader-http-server-mechanism-factory.cy.ts
@@ -95,7 +95,7 @@ describe("TESTS: Configuration => Subsystem => Security => Settings => Factories
       serviceLoaderHttpServerMechanismFactoryTableId,
       serviceLoaderHttpServiceMechanismFactories.update.name,
     );
-    cy.editForm(configurationFormId);
+    cy.editForm(configurationFormId, { waitForData: false });
     cy.text(configurationFormId, "module", "sample");
     cy.saveForm(configurationFormId);
     cy.verifySuccess();

--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -1,5 +1,9 @@
-Cypress.Commands.add("editForm", (formId) => {
+Cypress.Commands.add("editForm", (formId, { waitForData = true } = {}) => {
   const editButton = "#" + formId + ' a.clickable[data-operation="edit"]';
+  if (waitForData) {
+    // Wait for form data to load: find readonly spans without "empty" CSS class and with actual text content
+    cy.get(`#${formId}-readonly`).find("span[id$='-readonly']:not(.empty):not(:empty)").should("exist");
+  }
   cy.get(`#${formId}-editing`).should("not.be.visible");
   cy.get(editButton).click();
   // Workaround - JBEAP-25005,JBEAP-25046 - the form is sometimes not loaded in time and Cypress is not able to recover
@@ -189,7 +193,7 @@ declare global {
        *
        * @param formId - The ID of section which need to be edit.
        */
-      editForm(formId: string): Chainable<void>;
+      editForm(formId: string, options?: { waitForData?: boolean }): Chainable<void>;
       /**
        * Click on "Save" button to save current data in form.
        * @category Form Editing


### PR DESCRIPTION
stability improvement - the form editing started before the data was load cause reset of the form into read only state when data arrive. Also possibility to skip this check
