### PR TITLE
[HAL-2008] Update Keycloak image from 24.0 to latest

### DIFF
--- a/.github/workflows/manual-test-matrix-workflow.yaml
+++ b/.github/workflows/manual-test-matrix-workflow.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: "Check docker status"
         run: systemctl status docker
       - name: "Run npm install"
-        run: "npm install --ignore-scripts --before=\"$(date -d '7 days ago' --iso-8601=seconds)\""
+        run: 'npm install --ignore-scripts --before="$(date -d ''7 days ago'' --iso-8601=seconds)"'
       - name: "Install Cypress binary"
         run: "npx cypress install"
       - name: "Run compile"

--- a/.github/workflows/on-pull-request-workflow.yaml
+++ b/.github/workflows/on-pull-request-workflow.yaml
@@ -43,4 +43,4 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: true
         run: |
           SPECS="${{ steps.changed-files-specific.outputs.all_changed_files }}"
-          KEYCLOAK_IMAGE=quay.io/keycloak/keycloak:24.0 npm run test -- --browser=chrome --specs=$SPECS
+          KEYCLOAK_IMAGE=quay.io/keycloak/keycloak:latest npm run test -- --browser=chrome --specs=$SPECS

--- a/.github/workflows/reusable-build-project-workflow.yaml
+++ b/.github/workflows/reusable-build-project-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           firefox-version: "latest-esr"
       - name: "Run npm install"
-        run: "npm install --ignore-scripts --before=\"$(date -d '7 days ago' --iso-8601=seconds)\""
+        run: 'npm install --ignore-scripts --before="$(date -d ''7 days ago'' --iso-8601=seconds)"'
       - name: "Install Cypress binary"
         run: "npx cypress install"
       - name: "Run compile"

--- a/.github/workflows/scheduled-run-all-tests-workflow.yaml
+++ b/.github/workflows/scheduled-run-all-tests-workflow.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: "Check docker status"
         run: "systemctl status docker"
       - name: "Run npm install"
-        run: "npm install --ignore-scripts --before=\"$(date -d '7 days ago' --iso-8601=seconds)\""
+        run: 'npm install --ignore-scripts --before="$(date -d ''7 days ago'' --iso-8601=seconds)"'
       - name: "Install Cypress binary"
         run: "npx cypress install"
       - name: "Run compile"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm install
 in the root directory to download all of the NPM dependencies specified in `package.json`
 
 > **Security note:** To protect against npm supply chain attacks, it is recommended to use the following flags:
+>
 > - `--ignore-scripts` — prevents pre/post install scripts of dependencies from executing (main attack vector)
 > - `--before` — limits package resolution to versions published more than 7 days ago, relying on security teams removing compromised packages within that window
 >
@@ -54,6 +55,7 @@ in the root directory to download all of the NPM dependencies specified in `pack
 > ```
 >
 > Note: `--ignore-scripts` also skips the project's own `postinstall` hook and the Cypress binary download. Run the following steps manually afterwards:
+>
 > ```
 > npx cypress install
 > npm run compile

--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -114,7 +114,9 @@ Cypress.Commands.add("flip", (formId, attributeName, value) => {
   } else {
     cy.formInput(formId, attributeName).wait(1000).should("not.be.checked");
   }
-  cy.get('div[data-form-item-group="' + formId + "-" + attributeName + '-editing"] .bootstrap-switch-label:visible')
+  cy.get('div[data-form-item-group="' + formId + "-" + attributeName + '-editing"]')
+    .scrollIntoView()
+    .find(".bootstrap-switch-label")
     .click()
     .wait(1000);
   if (value) {


### PR DESCRIPTION
## Summary

- Update \`KEYCLOAK_IMAGE\` in GitHub CI from \`quay.io/keycloak/keycloak:24.0\` to \`quay.io/keycloak/keycloak:latest\`
- Fix flaky \`Configure management client secured by bearer token\` test: the \`ssl-required\` dropdown renders as a dropup with huge max-height, covering the \`bearer-only\` switch. Moved \`scrollIntoView()\` into \`cy.flip()\` so all boolean toggles scroll into view before being clicked.

## Background

The image was pinned to 24.0 as a temporary workaround for [HAL-2009](https://issues.redhat.com/browse/HAL-2009) / [HAL-2008](https://issues.redhat.com/browse/HAL-2008) ("Adjust the ability to secure the admin console with OpenID Connect to Keycloak 26+"). That issue has been resolved.

## Test run (Keycloak latest)

All 3 elytron-oidc-client specs (15 tests) passed using \`quay.io/keycloak/keycloak:latest\`:

- ✅ [All elytron-oidc-client tests — 15/15 passed](https://github.com/kstekovi/berg/actions/runs/29410215067)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)