### PR TITLE
Fix cy.flip() failing on multiple elements in wizard

### DIFF
--- a/packages/testsuite/cypress/support/form-editing.ts
+++ b/packages/testsuite/cypress/support/form-editing.ts
@@ -115,6 +115,8 @@ Cypress.Commands.add("flip", (formId, attributeName, value) => {
     cy.formInput(formId, attributeName).wait(1000).should("not.be.checked");
   }
   cy.get('div[data-form-item-group="' + formId + "-" + attributeName + '-editing"]')
+    .filter(":visible")
+    .first()
     .scrollIntoView()
     .find(".bootstrap-switch-label")
     .click()


### PR DESCRIPTION
Fix cy.flip() failing on multiple elements in wizard